### PR TITLE
vagrant boxのurlを32bit、64bit両対応にしたい

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,13 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "centos7"
+  config.vm.box = 'bizevo/centos7_64'
+  config.vm.box_url = 'https://f0fff3908f081cb6461b407be80daf97f07ac418.googledrive.com/host/0BwtuV7VyVTSkUG1PM3pCeDJ4dVE/centos7.box'
+
+  if ENV["PROCESSOR_ARCHITECTURE"] == 'x86'
+    puts "falling back to 32-bit guest architecture :("
+    config.vm.box = 'bizevo/centos6.4_i386'
+    config.vm.box_url = 'http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.4-i386-v20131103.box'
+  end
   config.vm.network "private_network", ip: "192.168.33.30"
 end

--- a/site-cookbooks/base/recipes/default.rb
+++ b/site-cookbooks/base/recipes/default.rb
@@ -26,9 +26,6 @@ execute 'change timezone' do
   command 'cp -p /usr/share/zoneinfo/Japan /etc/localtime'
 end
 
-gem_package 'bundler'
-gem_package 'padrino'
-
 package 'ImageMagick'
 package 'ImageMagick-devel'
 package 'libxml2-devel'
@@ -51,6 +48,12 @@ end
 
 ruby_build_ruby '2.1.3' do
   action :install
+end
+
+%w/bundler padrino/.each do |g|
+  gem_package g do
+    gem_binary '/usr/local/ruby/2.1.3/bin/gem'
+  end
 end
 
 cookbook_file '/home/webservice/.git-completion.bash' do


### PR DESCRIPTION
ENVで分岐する。

http://steve-jansen.github.io/blog/2014/03/14/configuring-vagrant-to-dynamically-match-guest-and-host-cpu-architectures/
